### PR TITLE
[BUGFIX] Prevent double-submit on delete-all button

### DIFF
--- a/src/views/list.tpl.html
+++ b/src/views/list.tpl.html
@@ -32,7 +32,7 @@
     <div class="row">
         <div class="col-xs-6">
             <p>
-                <button href="#/" class="btn btn-success"><span class="glyphicon glyphicon-ok-sign"></span> Alles
+                <button type="button" href="#/" class="btn btn-success"><span class="glyphicon glyphicon-ok-sign"></span> Alles
                     eingekauft!
                 </button>
             </p>


### PR DESCRIPTION
## Bug: Double Delete on 'Alles eingekauft!' click

**Problem:** The 'Alles eingekauft!' button lives inside a  but lacked . This caused two delete API calls per click:
1. Form's  → 
2. Button's implicit  type → form submit again

**Fix:** Added  to the button, preventing default form submission behavior. Only the intended  handler fires now.

**Impact:** Prevents duplicate DELETE API calls, potential race conditions, and items being deleted incorrectly when multiple users share the same list.

---
*Automated PR from Claw subagent (Jules continuous dev)*